### PR TITLE
Implementação de compilação de fontes abertos. Fix #282

### DIFF
--- a/package.json
+++ b/package.json
@@ -399,6 +399,12 @@
         ],
         "keybindings": [
             {
+                "command": "advpl.compileopenfiles",
+                "key": "ctrl+alt+f9",
+                "mac": "cmd+alt+f9",
+                "when": "editorLangId == advpl"
+            },
+            {
                 "command": "advpl.compile",
                 "key": "ctrl+f9",
                 "mac": "cmd+f9",


### PR DESCRIPTION
Fiz uma implementação da compilação dos arquivos abertos, ela só funciona com os arquivos abertos ou acionados após a abertura do vscode e utiliza a compilação de arquivos TXT, com certeza está longe de ser a melhor forma de implementação, mas foi o que consegui fazer com os conhecimentos que tenho de typescript.