### PR TITLE
Fix #386

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,7 +113,11 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('advpl.refreshReplay', () => replayTimeLineProvider.refresh());
 
     const serverView = new ServerManagementView();
-    vscode.window.registerTreeDataProvider('serversManagement', serverView.provider);
+
+    vscode.window.createTreeView("serversManagement", {
+        treeDataProvider : serverView.provider,
+        showCollapseAll : true
+    });
 
     // Evento acionado sempre que uma configuração é alterada no Workspace
     context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(e => {

--- a/src/prompts/checkbox.ts
+++ b/src/prompts/checkbox.ts
@@ -20,7 +20,8 @@ export default class CheckboxPrompt extends Prompt {
 		}, {});
 
 		const options: QuickPickOptions = {
-			placeHolder: this._question.message
+			placeHolder: this._question.message,
+			ignoreFocusOut: true
 		};
 
 		let quickPickOptions = Object.keys(choices);

--- a/src/prompts/confirm.ts
+++ b/src/prompts/confirm.ts
@@ -17,7 +17,8 @@ export default class ConfirmPrompt extends Prompt {
 		};
 
 		const options: QuickPickOptions = {
-			placeHolder: this._question.message
+			placeHolder: this._question.message,
+			ignoreFocusOut: true
 		};
 
 		return window.showQuickPick(Object.keys(choices), options)

--- a/src/prompts/expand.ts
+++ b/src/prompts/expand.ts
@@ -17,7 +17,8 @@ export default class ExpandPrompt extends Prompt {
 		}, {});
 
 		const options: QuickPickOptions = {
-			placeHolder: this._question.message
+			placeHolder: this._question.message,
+			ignoreFocusOut: true
 		};
 
 		return window.showQuickPick(Object.keys(choices), options)

--- a/src/prompts/input.ts
+++ b/src/prompts/input.ts
@@ -27,6 +27,7 @@ export default class InputPrompt extends Prompt {
 		}
 
 		this._options.placeHolder = placeHolder;
+		this._options.ignoreFocusOut = true;
 
 		return window.showInputBox(this._options)
 			.then(result => {

--- a/src/prompts/list.ts
+++ b/src/prompts/list.ts
@@ -17,7 +17,8 @@ export default class ListPrompt extends Prompt {
 		}, {});
 
 		const options: QuickPickOptions = {
-			 placeHolder: this._question.message
+			placeHolder: this._question.message,
+			ignoreFocusOut: true
 		};
 
 		return window.showQuickPick(Object.keys(choices), options)

--- a/src/prompts/password.ts
+++ b/src/prompts/password.ts
@@ -8,5 +8,6 @@ export default class PasswordPrompt extends InputPrompt {
 		super(question);
 
 		this._options.password = true;
+		this._options.ignoreFocusOut = true;
 	}
 }


### PR DESCRIPTION
- Adicionado opção nos prompts do Assistente, para não fechar o assistente quando o usuário retirar o foco do VsCode (ex.: consultar alguma porta/IP, caminho de rede, ...)
- Adicionado método padrão da API do VsCode para adicionar o recurso para condensar todos os itens de uma view no Gerenciador de Ambientes