### PR TITLE
Nova versão de appserver e opção de SSL

### DIFF
--- a/i18n/enu/out/src/commands/addAdvplEnvironment.i18n.json
+++ b/i18n/enu/out/src/commands/addAdvplEnvironment.i18n.json
@@ -12,6 +12,7 @@
 	"src.commands.addAdvplEnvironment.passwordText": "Password",
 	"src.commands.addAdvplEnvironment.includeListText": "Include list",
 	"src.commands.addAdvplEnvironment.enable": "Environment Enabled for Use?",
+	"src.commands.addAdvplEnvironment.SSL": "SSL?",
 	"src.extension.yesText": "Yes",
 	"src.extension.noText": "No"
 

--- a/i18n/esn/out/src/commands/addAdvplEnvironment.i18n.json
+++ b/i18n/esn/out/src/commands/addAdvplEnvironment.i18n.json
@@ -12,6 +12,7 @@
 	"src.commands.addAdvplEnvironment.passwordText": "Contraseña",
 	"src.commands.addAdvplEnvironment.includeListText": "Lista de includes",
 	"src.commands.addAdvplEnvironment.enable": "Entorno habilitado para uso?",
+	"src.commands.addAdvplEnvironment.SSL": "SSL?",
 	"src.extension.yesText": "Si",
 	"src.extension.noText": "No"
 }

--- a/i18n/ptb/out/src/commands/addAdvplEnvironment.i18n.json
+++ b/i18n/ptb/out/src/commands/addAdvplEnvironment.i18n.json
@@ -12,6 +12,7 @@
 	"src.commands.addAdvplEnvironment.passwordText": "Senha",
 	"src.commands.addAdvplEnvironment.includeListText": "Selecione as pastas de Include",
 	"src.commands.addAdvplEnvironment.enable": "Ambiente Habilitado para Uso?",
+	"src.commands.addAdvplEnvironment.SSL": "SSL?",
 	"src.extension.yesText": "Sim",
 	"src.extension.noText": "Não"
 }

--- a/package.json
+++ b/package.json
@@ -213,7 +213,11 @@
                             },
                             "serverVersion": {
                                 "type": "string",
-                                "enum": ["131227A","170117A","191205P"],
+                                "enum": [
+                                    "131227A",
+                                    "170117A",
+                                    "191205P"
+                                ],
                                 "default": "170117A",
                                 "description": "%advpl.contributes.configuration.properties.ADVPLENVIRONMENTS.items.properties.SERVERVERSION%"
                             },
@@ -271,11 +275,10 @@
                                 "type": "string",
                                 "default": "8486",
                                 "description": "%advpl.contributes.configuration.properties.ADVPLENVIRONMENTS.items.properties.WEBAPPPORT%"
-                            }
-                            ,
+                            },
                             "ssl": {
                                 "type": "boolean",
-                                "default": "false",
+                                "default": false,
                                 "description": "%advpl.contributes.configuration.properties.ADVPLENVIRONMENTS.items.properties.SSL%"
                             }
                         }

--- a/src/commands/addAdvplEnvironment.ts
+++ b/src/commands/addAdvplEnvironment.ts
@@ -10,7 +10,8 @@ const localize = nls.loadMessageBundle();
 export default function cmdAddAdvplEnvironment(context): any {
     const config = vscode.workspace.getConfiguration("advpl");
     const environments = config.get<Array<IEnvironment>>("environments");
-    let adapter = new CodeAdapter()
+    let adapter = new CodeAdapter();
+
     const questions = [{
         message: localize('src.commands.addAdvplEnvironment.envAppserverText', 'Environment AppServer'),
         validate: (env) => {
@@ -61,7 +62,7 @@ export default function cmdAddAdvplEnvironment(context): any {
         name: "appserverVersion",
         type: "list",
         default: '131227A',
-        choices: ['131227A', '170117A']
+        choices: ['131227A', '170117A','191205P']
     }, {
         message: localize('src.commands.addAdvplEnvironment.serverIpText', 'Server IP'),
         name: "server",
@@ -81,11 +82,13 @@ export default function cmdAddAdvplEnvironment(context): any {
 
             return true;
         }
-    }, {
+    },
+    {
         message: localize('src.commands.addAdvplEnvironment.userText', 'User'),
         name: "user",
         default: "Admin"
-    }, {
+    },
+    {
         message: localize('src.commands.addAdvplEnvironment.passwordText', 'Password'),
         name: "password",
         type: "password"
@@ -102,7 +105,18 @@ export default function cmdAddAdvplEnvironment(context): any {
         name: "includeList",
         type: 'folder',
         canSelectMany: true
-    }]
+    },
+    {
+        message: localize('src.commands.addAdvplEnvironment.SSL', 'SSL?'),
+        name: "ssl",
+        when: function (answers) {
+            return answers.appserverVersion == '191205P';
+        },
+        type: "list",
+        default: false,
+        choices: [false, true]
+    }];
+
     adapter.prompt(questions, answers => {
         const compile = new advplCompile();
         compile.runCipherPassword(answers.password, cipher => {
@@ -117,11 +131,11 @@ export default function cmdAddAdvplEnvironment(context): any {
                 includeList: answers.includeList,
                 user: answers.user,
                 smartClientPath: answers.smartClientPath,
-                enable: answers.enable == localize('src.extension.yesText', 'Yes') ? true : false
-
+                enable: answers.enable == localize('src.extension.yesText', 'Yes') ? true : false,
+                ssl: answers.ssl
             });
             config.update("environments", environments)
         })
 
-    })
+    });
 }

--- a/src/utils/IEnvironment.ts
+++ b/src/utils/IEnvironment.ts
@@ -12,4 +12,5 @@ export default interface IEnvironment{
     rpoType?: string;
     name?: string;
     enable?: boolean;
+    ssl?: boolean;
 }


### PR DESCRIPTION
**Implementação:** Na opção de criação de ambiente, foi implementada a nova versão do servidor, quando a mesma é selecionada é exibida também a opção de configuração de SSL.

**Correção:** A opção default do SSL estava como string, porém trata-se de um boolean.