### PR TITLE
Ajustes na visão do Gerenciador de ambientes

### DIFF
--- a/src/advplCompile.ts
+++ b/src/advplCompile.ts
@@ -461,4 +461,8 @@ export class advplCompile {
         });
     }
 
+    public getIsAlpha() : boolean {
+        return this.isAlpha;
+    }
+
 }

--- a/src/commands/addAdvplEnvironment.ts
+++ b/src/commands/addAdvplEnvironment.ts
@@ -120,7 +120,7 @@ export default function cmdAddAdvplEnvironment(context): any {
     adapter.prompt(questions, answers => {
         const compile = new advplCompile();
         compile.runCipherPassword(answers.password, cipher => {
-            cipher = cipher.replace(/\r?\n?/g, '')
+            cipher = cipher.replace(/\r?\n?/g, '');
             environments.push({
                 environment: answers.environment,
                 name: answers.name,
@@ -130,11 +130,11 @@ export default function cmdAddAdvplEnvironment(context): any {
                 passwordCipher: cipher,
                 includeList: answers.includeList,
                 user: answers.user,
-                smartClientPath: answers.smartClientPath,
+                smartClientPath: answers.smartClientPath + (compile.getIsAlpha() ? "\\" : ""),
                 enable: answers.enable == localize('src.extension.yesText', 'Yes') ? true : false,
                 ssl: answers.ssl
             });
-            config.update("environments", environments)
+            config.update("environments", environments);
         })
 
     });

--- a/src/serversManagementView.ts
+++ b/src/serversManagementView.ts
@@ -125,7 +125,8 @@ export class ServerManagementView {
 
 		let options: vscode.InputBoxOptions = {
 			prompt: localize('src.ServerManagementView.RENAME', "Rename"),
-			placeHolder: oldLabel,
+			placeHolder: localize('src.ServerManagementView.INFORMELABEL', "Enter the Label to change."),
+			value: oldLabel,
 			validateInput: function (newLabel: string) {
 
 				// Não permite label vazio


### PR DESCRIPTION
- Ajustado ícones usados no gerenciador de ambientes para o [novo padrão do VsCode](https://github.com/microsoft/vscode-icons)
- Melhorado opção para renomear os itens do Gerenciador de Ambientes