### PR TITLE
Correção de identação de textos gerados pelo GIT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /out/
 node_modules
+*.vsix

--- a/src/codeFormat/formatting.ts
+++ b/src/codeFormat/formatting.ts
@@ -81,13 +81,16 @@ class RangeFormatting implements DocumentRangeFormattingEditProvider {
       const text = line.text.trimRight();
       let lastRule: RuleMatch =
         formattingRules.openStructures[
-          formattingRules.openStructures.length - 1
+        formattingRules.openStructures.length - 1
         ];
       let foundIgnore: any[] = rulesIgnored.filter(rule => {
         return lastRule && lastRule.rule && rule.id === lastRule.rule.id;
       });
-      // dentro do BeginSql não mexe na identação
-      if (foundIgnore.length > 0 && !text.match(foundIgnore[0].end)) {
+      // tratamento para não mexer nas linhas de erros do GIT
+      if (text.match('^' + ('\\<'.repeat(7))) || text.match('^' + ('\\>'.repeat(7))) || text.match('^' + ('\\='.repeat(7)))) {
+        result.push(TextEdit.replace(line.range, text))
+        // dentro de algumas estruturas não identa
+      } else if (foundIgnore.length > 0 && !text.match(foundIgnore[0].end)) {
         result.push(TextEdit.replace(line.range, text));
       } else {
         if (

--- a/src/codeFormat/formmatingRules.ts
+++ b/src/codeFormat/formmatingRules.ts
@@ -71,7 +71,12 @@ export class FormattingRules {
         }
 
         // removo textos comentados para facilitar a análise
-        line = line.split(/\/\//)[0].trim();
+        if (lastRule &&
+          lastRule.rule &&
+          lastRule.rule.id !== 'comment' &&
+          lastRule.rule.id !== 'protheus doc') {
+          line = line.split(/\/\//)[0].trim();
+        }
 
         if (
           line.match(rule.end) &&
@@ -230,7 +235,7 @@ export class FormattingRules {
       {
         id: 'while',
         begin: /^(\s*)(do)?(\s*)(while)/i,
-        end: /^(\s*)(end)(do)?$/i
+        end: /^(\s*)(end)(\s*)(do)?$/i
       },
       {
         id: 'wsrestful',

--- a/src/codeFormat/formmatingRules.ts
+++ b/src/codeFormat/formmatingRules.ts
@@ -217,7 +217,7 @@ export class FormattingRules {
           /^(\s*)(if)(\t|\ |\!)*(.)*(\;)+(.)*(\;)+(.)*(endif)/i
         ],
         middle: /^(\s*)((else)|(elseif))(\t|\ |\(|;|\/\*|$)/i,
-        end: /^(\s*)(end)(w*)(if)?$/i
+        end: /^(\s*)(end)(\s)*(if)?$/i
       },
       {
         id: 'structure',

--- a/src/codeFormat/formmatingRules.ts
+++ b/src/codeFormat/formmatingRules.ts
@@ -70,6 +70,9 @@ export class FormattingRules {
           line = 'if(' + line;
         }
 
+        // removo textos comentados para facilitar a análise
+        line = line.split(/\/\//)[0].trim();
+
         if (
           line.match(rule.end) &&
           lastRule &&
@@ -104,10 +107,10 @@ export class FormattingRules {
         }
       }
 
-      return isNull(finddedRule);
+      return finddedRule === null;
     });
 
-    if (!isNull(finddedRule)) {
+    if (finddedRule !== null) {
       this.lastMatch = finddedRule;
       return true;
     }


### PR DESCRIPTION
Estavam sendo identados os textos de controles do git.
<<<<<<<
=======
>>>>>>>

Foi colocado um tratamento para não mexer nesses textos.

Foi corrigida a identificação de Estrutura de IF terminada com "End If"

Foi corrigida a identação quando após as expressões existe comentário de linha "//".